### PR TITLE
Fix invalid cast

### DIFF
--- a/src/application.vala
+++ b/src/application.vala
@@ -40,7 +40,7 @@ public class Pomerode.Application : Adw.Application {
     }
 
     private void on_preferences_action () {
-        var preferences = new Pomerode.PreferencesWindow ((Adw.Window) this.active_window);
+        var preferences = new Pomerode.PreferencesWindow ((Adw.ApplicationWindow) this.active_window);
         preferences.present ();
     }
 }

--- a/src/preferences.vala
+++ b/src/preferences.vala
@@ -40,7 +40,7 @@ public class PreferencesWindow : Adw.PreferencesWindow {
     private const int MAX_LONG_BREAK_DURATION = 60;
     private const int MAX_INTERVALS = 10;
 
-    public PreferencesWindow (Adw.Window parent) {
+    public PreferencesWindow (Adw.ApplicationWindow parent) {
         Object (transient_for: parent, modal: true);
         setup_settings();
         connect_signals();


### PR DESCRIPTION
The error "invalid cast from 'PomerodeWindow' to 'AdwWindow'" is shown when you open the preferences window from the menu button.

This is because Adw.ApplicationWindow, the parent class of Pomerode.Window, does not inherit Adw.Window. So make sure to cast to the correct parent class.